### PR TITLE
Remove unnecessary zero checks for unsigned types

### DIFF
--- a/src/plate.cpp
+++ b/src/plate.cpp
@@ -49,12 +49,6 @@ plate::plate(long seed, const float* m, size_t w, size_t h, size_t _x, size_t _y
     if (w <= 0 || h <= 0) {
         throw invalid_argument("width and height of the plate should be greater than zero");
     }
-    if (_x < 0 || _y <0) {
-        throw invalid_argument("coordinates of the plate should be greater or equal to zero");
-    }
-    if (plate_age < 0) {
-        throw invalid_argument("age of the plate should be greater or equal to zero");
-    }
 
     const size_t plate_area = w * h;
     const double angle = 2 * M_PI * _randsource() / (double)_randsource.max();

--- a/src/rectangle.cpp
+++ b/src/rectangle.cpp
@@ -34,13 +34,6 @@ size_t Rectangle::getMapIndex(size_t* px, size_t* py) const throw()
 	x -= ilft; // Calculate offset within local map.
 	y -= itop;
 
-    if (x < 0) {
-        throw std::invalid_argument("failure x");
-    }
-    if (y < 0) {
-        throw std::invalid_argument("failure y");
-    }
-
     if (xOk && yOk) {
         *px = x;
         *py = y;

--- a/src/rectangle.hpp
+++ b/src/rectangle.hpp
@@ -57,7 +57,7 @@ public:
 
     bool contains(const size_t x, const size_t y) const
     {
-        return (x >= 0 && x < _width && y >= 0 && y < _height);
+        return (x < _width && y < _height);
     }
 
     void normalize(size_t& x, size_t& y) const
@@ -73,7 +73,7 @@ public:
 
     size_t lineIndex(const size_t y) const
     {
-        if (y<0 || y>=_height){
+        if (y>=_height){
             throw invalid_argument("WorldDimension::line_index: y is not valid");
         }
         return indexOf(0, y);


### PR DESCRIPTION
std::size_t is an unsigned integer type which can't hold a value below zero.
Therefore checking for < 0 is unnecessary. Removing so called tautological
expressions which are always true as well.